### PR TITLE
Add link to react-native PR

### DIFF
--- a/types/metroRequire.d.ts
+++ b/types/metroRequire.d.ts
@@ -1,6 +1,9 @@
 // Based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack-env/index.d.ts
 // Adds support for the runtime `require.context` method.
 // https://github.com/facebook/metro/pull/822/
+//
+// Separate file required until the types land in react-native itself:
+// https://github.com/facebook/react-native/pull/41421
 
 declare var module: NodeModule;
 


### PR DESCRIPTION
Hi @EvanBacon, thanks for this demo!

Since this repo is ranking well in search engines and users are finding it when looking for `require.context()` TypeScript types, I thought I would also add a link to the `require.context()` types file to direct people to watch the `react-native` PR which adds types to React Native:

- https://github.com/facebook/react-native/pull/41421